### PR TITLE
Allow to generate MD5 hashes in FIPS enabled environments.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ History
 1.0rc1 (unreleased)
 -------------------
 
+- Allow to generate MD5 hashes in FIPS enabled environments.
+  [frapell]
+
 - Fix DN comparison in ``LDAPStorage.node_by_dn`` to ignore case sensitivity.
   [rnix]
 

--- a/src/node/ext/ldap/base.py
+++ b/src/node/ext/ldap/base.py
@@ -41,7 +41,10 @@ def md5digest(key):
     :param key: Key to create a md5 hex digest for.
     :return digest: hex digest.
     """
-    m = hashlib.md5()
+    try:
+        m = hashlib.md5()
+    except ValueError:
+        m = hashlib.md5(usedforsecurity=False)
     m.update(ensure_bytes(key))
     return m.hexdigest()
 


### PR DESCRIPTION
Fixes https://github.com/conestack/node.ext.ldap/issues/59