### PR TITLE
Remove argparser if Python Version >= 3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-from setuptools import find_packages
-from setuptools import setup
 import codecs
 import os
+import sys
+
+from setuptools import find_packages, setup
 
 
 def read_file(name):
@@ -12,6 +13,23 @@ def read_file(name):
     ) as f:
         return f.read()
 
+def get_install_requires():
+
+    packages = [
+        'bda.cache',
+        'node.ext.ugm>=1.0',
+        'passlib',
+        'python-ldap>=2.4.14',
+        'setuptools',
+        'argparse'
+    ]
+
+    if sys.version_info >= (3,2):
+        packages.remove('argparse')
+    
+    return packages
+
+install_requires = get_install_requires()
 
 version = '1.1.dev0'
 shortdesc = 'LDAP/AD convenience with Node-trees based on python-ldap'
@@ -52,14 +70,7 @@ setup(
     namespace_packages=['node', 'node.ext'],
     include_package_data=True,
     zip_safe=False,
-    install_requires=[
-        'argparse',
-        'bda.cache',
-        'node.ext.ugm>=1.0',
-        'passlib',
-        'python-ldap>=2.4.14',
-        'setuptools'
-    ],
+    install_requires=install_requires,
     extras_require={
         'test': [
             'coverage',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ import codecs
 import os
 import sys
 
-from setuptools import find_packages, setup
+from setuptools import find_packages
+from setuptools import setup
 
 
 def read_file(name):


### PR DESCRIPTION
argparse is a builtin module in python >= 3.2, no reason to add this as install_requires for modern python versions.
i use this package and OCRmyPDF in a project. I install a Plone System via buildout with some dependencies. If the ''argparse" package installed via pypi, because the "install_requires" directive from this package require it, then the installation breaks.
i think its safe to remove this for python >=3.2, beacause it's builtin in the standard lib.
