### PR TITLE
ldap timeouts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ History
 1.1 (unreleased)
 ----------------
 
+- Add properties `conn_timeout` and `op_timeout` (both not set by default)
+  to configure ``ReconnectLDAPObject``.
+  [mamico]
+
 - Adopt lifecycle related changes from ``node`` 1.1.
   [rnix]
 
@@ -481,4 +485,3 @@ History
 
 - refactor form ``bda.ldap``.
   [rnix, chaoflow]
-

--- a/src/node/ext/ldap/base.py
+++ b/src/node/ext/ldap/base.py
@@ -105,6 +105,8 @@ class LDAPConnector(object):
         self._tls_cacert_file = props.tls_cacertfile
         self._retry_max = props.retry_max
         self._retry_delay = props.retry_delay
+        self._conn_timeout = props.conn_timeout
+        self._op_timeout = props.op_timeout
         self._con = None
 
     def bind(self):
@@ -125,6 +127,12 @@ class LDAPConnector(object):
         # Directory More info: https://www.python-ldap.org/faq.html#usage
         self._con.set_option(ldap.OPT_REFERRALS, 0)
         self._con.protocol_version = self.protocol
+        # Set the connection timeout
+        if self._conn_timeout > 0:
+            self._con.set_option(ldap.OPT_NETWORK_TIMEOUT, self._conn_timeout)
+        # Set the operations timeout
+        if self._op_timeout > 0:
+            self._con.timeout = self._op_timeout
         if self._start_tls:  # pragma: no cover
             # ignore in tests for now. nevertheless provide a test environment
             # for TLS and SSL later

--- a/src/node/ext/ldap/interfaces.py
+++ b/src/node/ext/ldap/interfaces.py
@@ -31,7 +31,7 @@ class ILDAPProps(Interface):
 
     cache = Attribute('Flag wether to use cache or not')
 
-    timeout = Attribute('Timeout in seconds')
+    timeout = Attribute('Cache timeout in seconds')
 
     start_tls = Attribute('TLS enabled')
 
@@ -58,6 +58,9 @@ class ILDAPProps(Interface):
 
     page_size = Attribute('Page size for LDAP queries.')
 
+    conn_timeout = Attribute('LDAP connecton timeout')
+
+    op_timemout = Attribute('LDAP operations timeout')
 
 class ILDAPPrincipalsConfig(Interface):
     """LDAP principals configuration interface.

--- a/src/node/ext/ldap/properties.py
+++ b/src/node/ext/ldap/properties.py
@@ -43,7 +43,7 @@ class LDAPServerProperties(object):
         user='',
         password='',
         cache=True,  # XXX: default False
-        timeout=43200,
+        timeout=43200,  # cache timeout
         uri=None,
         start_tls=0,
         ignore_cert=0,
@@ -55,7 +55,9 @@ class LDAPServerProperties(object):
         retry_delay=10.0,
         multivalued_attributes=MULTIVALUED_DEFAULTS,
         binary_attributes=BINARY_DEFAULTS,
-        page_size=1000
+        page_size=1000,
+        conn_timeout=-1,
+        op_timeout=-1,
     ):
         """Take the connection properties as arguments.
 
@@ -96,10 +98,14 @@ class LDAPServerProperties(object):
             multivalued to be returned as list.
         :param binary_attributes: Set of attributes names considered as binary.
             (no text conversion)
-        :param page_size: Oage size for LDAP search requests, defaults to 1000.
+        :param page_size: Page size for LDAP search requests, defaults to 1000.
             Number of objects requested at once.
             In iterations after this number of objects a new search query is
             sent for the next batch using returned the LDAP cookie.
+        :param conn_timeout: Connection timeout in seconds, defaults to -1 (i.e.
+            not defined).
+        :param op_timeout: Operations timeout in seconds, defaults to -1 (i.e.
+            not defined).
         """
         if uri is None:
             # old school
@@ -122,6 +128,8 @@ class LDAPServerProperties(object):
         self.multivalued_attributes = multivalued_attributes
         self.binary_attributes = binary_attributes
         self.page_size = page_size
+        self.conn_timeout = conn_timeout
+        self.op_timeout = op_timeout
 
 
 # B/C

--- a/src/node/ext/ldap/tests/test_base.py
+++ b/src/node/ext/ldap/tests/test_base.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from bda.cache.nullcache import NullCacheManager
 from ldap import MOD_REPLACE
+from ldap import OPT_NETWORK_TIMEOUT
 from node.ext.ldap import LDAPCommunicator
 from node.ext.ldap import LDAPConnector
 from node.ext.ldap import LDAPProps
@@ -61,7 +62,9 @@ class TestBase(NodeTestCase):
             server=host,
             port=port,
             user=binddn,
-            password=bindpw
+            password=bindpw,
+            conn_timeout=5,
+            op_timeout=600,
         )
 
         # Create connector.
@@ -72,6 +75,10 @@ class TestBase(NodeTestCase):
 
         # Bind to directory.
         communicator.bind()
+
+        # Check whether the timeout values are correctly set
+        self.assertEqual(connector._con.get_option(OPT_NETWORK_TIMEOUT), 5)
+        self.assertEqual(connector._con.timeout, 600)
 
         # Search fails if baseDN is not set and not given to search function
         self.assertEqual(communicator.baseDN, '')


### PR DESCRIPTION
Add the properties for connection and operations timeout.
Prerequisites for adding the timeouts' config in https://github.com/collective/pas.plugins.ldap

(see also https://github.com/collective/pas.plugins.ldap/issues/61)